### PR TITLE
fix: Echo script name instead of full path when showing help

### DIFF
--- a/readlogs
+++ b/readlogs
@@ -72,8 +72,10 @@ read_logs() {
 
 # Main script execution
 if [[ $# -lt 3 ]]; then
-    echo -e "\e[34mUsage:\e[0m $0 <start_date> <end_date> <log_file1> [<log_file2> ... <log_fileN>]" >&2
-    echo -e "\e[34mExample:\e[0m $0 '2023-10-01 00:00:00' '2023-10-31 23:59:59' /var/log/caddy/*.log" >&2
+    local script_name;
+    script_name="$(basename -- "$0")"
+    echo -e "\e[34mUsage:\e[0m $script_name <start_date> <end_date> <log_file1> [<log_file2> ... <log_fileN>]" >&2
+    echo -e "\e[34mExample:\e[0m $script_name '2023-10-01 00:00:00' '2023-10-31 23:59:59' /var/log/caddy/*.log" >&2
     exit 1
 fi
 


### PR DESCRIPTION
When running the script with an unexpected number of arguments (or the `--help` flag), the script provides usage instructions. It used to display the whole path of the executable, which is not desirable when installing it. Now it only displays the filename.